### PR TITLE
feat: Added ColorPrinter class to print colored text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,21 +11,98 @@
 
 ### Synchronized Chat
 
-#### To run the server
+### Compile the classes
+
+From the root of the project
 
 ```bash
-java ./syncChat/Server.java <portNumber>
+javac -d <pathToStoreClassFiles> syncChat/Server.java
+javac -d <pathToStoreClassFiles> syncChat/Client.java
 ```
 
-#### To join as a client
+### To run the server
+
+From the root of the project
 
 ```bash
-java ./syncChat/Client.java <hostname> <portNumber>
+cd <pathToTheStoredClassFiles>
+java syncChat.Server <portNumber>
+```
+
+### To join as a client
+
+From the root of the project
+
+```bash
+cd <pathToTheStoredClassFiles>
+java syncChat.Server <hostname> <portNumber>
 ```
 
 Example:
 
 ![Synchronized Chat Example](./syncChatExample.png)
+
+## `utils` package
+
+### `ColorPrinter`
+
+Uses [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for colored text in terminal
+
+### Importing the class
+
+```java
+import utils.ColorPrinter;
+```
+
+`ColorPrinter` class contains many font colors and background colors as static properties. These properties are strings and can be used as follows:
+
+### Basic Usage
+
+```java
+import utils.ColorPrinter;
+...
+System.out.println(ColorPrinter.RED + "This text is RED! " + ColorPrinter.BLUE + "This text is BLUE!" + ColorPrinter.RESET);
+// Don't forget to use RESET after the string to reset the terminal to its original font colors
+```
+
+### `println` method
+
+```java
+public static String println(String x, String color); // returns string `x` in `color` color
+
+public static void println(String x); // Prints onto the console - No colors - Terminal default
+
+// Notice that we don't have to use RESET anymore, the method does that internally
+System.out.println(ColorPrinter.println("This text is RED!", "RED")); // Red colored text with new line character in the end
+```
+
+### `printf` method
+
+```java
+public static String printf(String x);
+// Usage
+
+// Wrap the text to be colored in curly braces with $<colorName>{text}
+System.out.println(ColorPrinter.printf("$YELLOW{This text is yellow!}, and $RED{this is RED!}"));
+
+// Escape the `}` character using `\`
+System.out.println(ColorPrinter.printf("$YELLOW{This text is yellow and it contains {\\} - curly braces!}"));
+// Output: `This text is yellow and it contains {} - curly braces!` in yellow.
+
+
+public static String printf(String x, String... args);
+// Like the traditional println method in System.out
+// Usage
+System.out.println(ColorPrinter.printf("${This text is yellow}, ${this is cyan}"), "YELLOW", "CYAN");
+```
+
+### Colors provided
+
+You can see the colors from the class [here](utils/ColorPrinter.java)
+
+### Things to look out for
+
+- All methods except `println(String x)` _return_ a string.
 
 ## Looking to help?
 

--- a/syncChat/Server.java
+++ b/syncChat/Server.java
@@ -1,5 +1,7 @@
 package syncChat;
 
+import utils.ColorPrinter;
+
 import java.net.*;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
@@ -82,17 +84,17 @@ public class Server implements Runnable {
             try {
                 in = new BufferedReader(new InputStreamReader(client.getInputStream()));
                 out = new PrintWriter(client.getOutputStream(), true);
-                out.println(
-                        "This chat system is like discord DM, you and other users get to send messages to each other. Send \""
-                                + endCodeWord + "\" to end the session anytime!\nPlease enter your username: ");
+                out.println(ColorPrinter.printf("$YELLOW_BRIGHT{This chat system is like group chat, you and other users get to send messages to each other.} \nSend $PURPLE_BOLD_BRIGHT{\""
+                                + endCodeWord + "\"} to end the session anytime!\n$CYAN_BOLD_BRIGHT{Please enter your username:} ")
+                        );
                 String inpName = in.readLine();
                 while (!validNickname(inpName)) {
-                    out.println("Please enter your username: ");
+                    out.println(ColorPrinter.printf("$CYAN_BOLD_BRIGHT{Please enter your username: }"));
                     inpName = in.readLine();
                 }
                 username = inpName;
-                System.out.println(username + " has connected");
-                broadcast(username + " has joined the chat!");
+                System.out.println(ColorPrinter.printf("$YELLOW_BRIGHT{" + username + "}") + " has connected");
+                broadcast(ColorPrinter.printf("$YELLOW_BRIGHT{" + username + "}") + " has joined the chat!");
                 // The main loop
                 String message;
                 while ((message = in.readLine()) != null) {
@@ -100,7 +102,7 @@ public class Server implements Runnable {
                     if (message.startsWith("\\")) {
                         handleCommands(message);
                     }
-                    broadcast(username + ": " + message);
+                    broadcast(ColorPrinter.printf("$YELLOW_BRIGHT{" + username + "}") + ": " + message);
                 }
             } catch (IOException e) {
                 // TODO handle IOException

--- a/utils/ColorPrinter.java
+++ b/utils/ColorPrinter.java
@@ -1,0 +1,191 @@
+package utils;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Map.entry;
+
+public class ColorPrinter {
+    public static final Map<String, String> Colors = Map.<String, String>ofEntries(
+            entry("RESET", "\033[0m"),
+            entry("BLACK", "\033[0;30m"),
+            entry("RED", "\033[0;31m"),
+            entry("GREEN", "\033[0;32m"),
+            entry("YELLOW", "\033[0;33m"),
+            entry("BLUE", "\033[0;34m"),
+            entry("PURPLE", "\033[0;35m"),
+            entry("CYAN", "\033[0;36m"),
+            entry("WHITE", "\033[0;37m"),
+            entry("BLACK_BOLD", "\033[1;30m"),
+            entry("RED_BOLD", "\033[1;31m"),
+            entry("GREEN_BOLD", "\033[1;32m"),
+            entry("YELLOW_BOLD", "\033[1;33m"),
+            entry("BLUE_BOLD", "\033[1;34m"),
+            entry("PURPLE_BOLD", "\033[1;35m"),
+            entry("CYAN_BOLD", "\033[1;36m"),
+            entry("WHITE_BOLD", "\033[1;37m"),
+            entry("BLACK_UNDERLINED", "\033[4;30m"),
+            entry("RED_UNDERLINED", "\033[4;31m"),
+            entry("GREEN_UNDERLINED", "\033[4;32m"),
+            entry("YELLOW_UNDERLINED", "\033[4;33m"),
+            entry("BLUE_UNDERLINED", "\033[4;34m"),
+            entry("PURPLE_UNDERLINED", "\033[4;35m"),
+            entry("CYAN_UNDERLINED", "\033[4;36m"),
+            entry("WHITE_UNDERLINED", "\033[4;37m"),
+            entry("BLACK_BACKGROUND", "\033[40m"),
+            entry("RED_BACKGROUND", "\033[41m"),
+            entry("GREEN_BACKGROUND", "\033[42m"),
+            entry("YELLOW_BACKGROUND", "\033[43m"),
+            entry("BLUE_BACKGROUND", "\033[44m"),
+            entry("PURPLE_BACKGROUND", "\033[45m"),
+            entry("CYAN_BACKGROUND", "\033[46m"),
+            entry("WHITE_BACKGROUND", "\033[47m"),
+            entry("BLACK_BRIGHT", "\033[0;90m"),
+            entry("RED_BRIGHT", "\033[0;91m"),
+            entry("GREEN_BRIGHT", "\033[0;92m"),
+            entry("YELLOW_BRIGHT", "\033[0;93m"),
+            entry("BLUE_BRIGHT", "\033[0;94m"),
+            entry("PURPLE_BRIGHT", "\033[0;95m"),
+            entry("CYAN_BRIGHT", "\033[0;96m"),
+            entry("WHITE_BRIGHT", "\033[0;97m"),
+            entry("BLACK_BOLD_BRIGHT", "\033[1;90m"),
+            entry("RED_BOLD_BRIGHT", "\033[1;91m"),
+            entry("GREEN_BOLD_BRIGHT", "\033[1;92m"),
+            entry("YELLOW_BOLD_BRIGHT", "\033[1;93m"),
+            entry("BLUE_BOLD_BRIGHT", "\033[1;94m"),
+            entry("PURPLE_BOLD_BRIGHT", "\033[1;95m"),
+            entry("CYAN_BOLD_BRIGHT", "\033[1;96m"),
+            entry("WHITE_BOLD_BRIGHT", "\033[1;97m"),
+            entry("BLACK_BACKGROUND_BRIGHT", "\033[0;100m"),
+            entry("RED_BACKGROUND_BRIGHT", "\033[0;101m"),
+            entry("GREEN_BACKGROUND_BRIGHT", "\033[0;102m"),
+            entry("YELLOW_BACKGROUND_BRIGHT", "\033[0;103m"),
+            entry("BLUE_BACKGROUND_BRIGHT", "\033[0;104m"),
+            entry("PURPLE_BACKGROUND_BRIGHT", "\033[0;105m"),
+            entry("CYAN_BACKGROUND_BRIGHT", "\033[0;106m"),
+            entry("WHITE_BACKGROUND_BRIGHT", "\033[0;107m")
+    );
+    public static final String RESET = "\033[0m"; // Text Reset
+
+    // Regular Colors
+    public static final String BLACK = "\033[0;30m"; // BLACK
+    public static final String RED = "\033[0;31m"; // RED
+    public static final String GREEN = "\033[0;32m"; // GREEN
+    public static final String YELLOW = "\033[0;33m"; // YELLOW
+    public static final String BLUE = "\033[0;34m"; // BLUE
+    public static final String PURPLE = "\033[0;35m"; // PURPLE
+    public static final String CYAN = "\033[0;36m"; // CYAN
+    public static final String WHITE = "\033[0;37m"; // WHITE
+
+    // Bold
+    public static final String BLACK_BOLD = "\033[1;30m"; // BLACK
+    public static final String RED_BOLD = "\033[1;31m"; // RED
+    public static final String GREEN_BOLD = "\033[1;32m"; // GREEN
+    public static final String YELLOW_BOLD = "\033[1;33m"; // YELLOW
+    public static final String BLUE_BOLD = "\033[1;34m"; // BLUE
+    public static final String PURPLE_BOLD = "\033[1;35m"; // PURPLE
+    public static final String CYAN_BOLD = "\033[1;36m"; // CYAN
+    public static final String WHITE_BOLD = "\033[1;37m"; // WHITE
+
+    // Underline
+    public static final String BLACK_UNDERLINED = "\033[4;30m"; // BLACK
+    public static final String RED_UNDERLINED = "\033[4;31m"; // RED
+    public static final String GREEN_UNDERLINED = "\033[4;32m"; // GREEN
+    public static final String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
+    public static final String BLUE_UNDERLINED = "\033[4;34m"; // BLUE
+    public static final String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
+    public static final String CYAN_UNDERLINED = "\033[4;36m"; // CYAN
+    public static final String WHITE_UNDERLINED = "\033[4;37m"; // WHITE
+
+    // Background
+    public static final String BLACK_BACKGROUND = "\033[40m"; // BLACK
+    public static final String RED_BACKGROUND = "\033[41m"; // RED
+    public static final String GREEN_BACKGROUND = "\033[42m"; // GREEN
+    public static final String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
+    public static final String BLUE_BACKGROUND = "\033[44m"; // BLUE
+    public static final String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
+    public static final String CYAN_BACKGROUND = "\033[46m"; // CYAN
+    public static final String WHITE_BACKGROUND = "\033[47m"; // WHITE
+
+    // High Intensity
+    public static final String BLACK_BRIGHT = "\033[0;90m"; // BLACK
+    public static final String RED_BRIGHT = "\033[0;91m"; // RED
+    public static final String GREEN_BRIGHT = "\033[0;92m"; // GREEN
+    public static final String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
+    public static final String BLUE_BRIGHT = "\033[0;94m"; // BLUE
+    public static final String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
+    public static final String CYAN_BRIGHT = "\033[0;96m"; // CYAN
+    public static final String WHITE_BRIGHT = "\033[0;97m"; // WHITE
+
+    // Bold High Intensity
+    public static final String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
+    public static final String RED_BOLD_BRIGHT = "\033[1;91m"; // RED
+    public static final String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
+    public static final String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
+    public static final String BLUE_BOLD_BRIGHT = "\033[1;94m"; // BLUE
+    public static final String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
+    public static final String CYAN_BOLD_BRIGHT = "\033[1;96m"; // CYAN
+    public static final String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
+
+    // High Intensity backgrounds
+    public static final String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
+    public static final String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
+    public static final String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
+    public static final String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
+    public static final String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
+    public static final String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
+    public static final String CYAN_BACKGROUND_BRIGHT = "\033[0;106m"; // CYAN
+    public static final String WHITE_BACKGROUND_BRIGHT = "\033[0;107m"; // WHITE
+
+    public static void println(String x) {
+        // Maybe a default color - white for now
+        System.out.println(x);
+    }
+
+    public static String printfBasic(String x, String... args) {
+        String[] colors;
+        if (args[args.length - 1].equals(RESET)) {
+
+            colors = new String[args.length];
+        } else {
+            colors = new String[args.length + 1];
+
+        }
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].endsWith("m")) {
+                colors[i] = args[i];
+            } else {
+                colors[i] = ColorPrinter.Colors.get(args[i]);
+            }
+        }
+        if (colors.length != args.length) {
+            colors[args.length] = RESET;
+        }
+        return String.format(x + "%s", (Object[]) colors);
+    }
+
+    public static String printf(String x) {
+        Pattern pattern = Pattern.compile("\\$([\\S+]+)\\{(.*?)(?<!\\\\)}");
+        Matcher matcher = pattern.matcher(x);
+        return matcher.replaceAll(m -> Colors.get(m.group(1)) + m.group(2) + RESET);
+    }
+
+    public static String printf(String x, String... args){
+        x = x.replaceAll("\\$\\{(.*?)(?<!\\\\)}", "%s" + "$1" + RESET);
+        String[] colors = new String[args.length + 1];
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].endsWith("m")) {
+                colors[i] = args[i];
+            } else {
+                colors[i] = ColorPrinter.Colors.get(args[i]);
+            }
+        }
+        return String.format(x, (Object[]) colors);
+    }
+
+    public static String println(String x, String color) {
+        String COLOR = ColorPrinter.Colors.get(color);
+        return (COLOR + x + RESET);
+    }
+}


### PR DESCRIPTION
# #4 Add styles to text printed out in the terminal

- Added the class `ColorPrinter`, to the `utils` package, whose static methods can be used to get strings with [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
- The returned strings can be used to print colored text in the terminal
- Also updated CONTIBUTING.md to include the details on how to use the class

### All the available colors/styles

<img width="1120" alt="colors" src="https://user-images.githubusercontent.com/96474794/194586127-3e40a400-79f1-4f92-94a8-caaf59f9474b.png">

*ps:* I have added colored text in very few places in the chat application as I wasn't sure what would look good. But the `ColorPrinter` class should make future changes to styles much easier

<img width="749" alt="terminalColors" src="https://user-images.githubusercontent.com/96474794/194587293-5224cf21-7ee9-434f-9f92-92e46a37422d.png">
